### PR TITLE
added change to hf cache

### DIFF
--- a/charts/app-stable-diffusion/templates/pvc.yaml
+++ b/charts/app-stable-diffusion/templates/pvc.yaml
@@ -5,8 +5,6 @@ metadata:
   name: {{ include "app.fullname" . }}-cache
   labels:
     {{- include "app.labels" $ | nindent 4 }}
-  annotations:
-    "helm.sh/resource-policy": keep
 spec:
   accessModes:
     - {{ .Values.HFCacheVolume.accessMode }}

--- a/charts/app-stable-diffusion/values.yaml
+++ b/charts/app-stable-diffusion/values.yaml
@@ -117,5 +117,5 @@ modelDownload:
 
 HFCacheVolume:
   enabled: true
-  storage: 20Gi
+  storage: 40Gi
   accessMode: ReadWriteOnce


### PR DESCRIPTION
new stable diffusion model is 16gb, all repo > 20gb
https://huggingface.co/stabilityai/stable-diffusion-3.5-large/tree/main

if you'd like to have multiple we don't want to block you
Also, removed keep policy for the storage, so if you're installing an app multiple times, we're re-downloading